### PR TITLE
Fix '[' syntax error when not specified --docs or --sources option.

### DIFF
--- a/svm
+++ b/svm
@@ -447,6 +447,11 @@ get_stable(){
 
 cmd="$1"
 
+# download scala-sources if source_on=1
+source_on=0
+# download scala-devel-docs if docs_on=1
+docs_on=0
+
 for o in $*
 do
   case "${o}" in


### PR DESCRIPTION
--docs, --sourcesオプションを指定せずにインストールを行った場合に以下のエラーが発生する不具合を修正。

```
svm: 228 行: [: -eq: 単項演算子が予期されます
svm: 243 行: [: -eq: 単項演算子が予期されます
```

値が空の変数を `[ ${docs_on} -eq 1 ]` のような形で評価すると `-eq` の左辺が空になり構文エラーになるため、変数の初期値を設定するように修正。
