### PR TITLE
Fix rm command error when installed first time.

### DIFF
--- a/svm
+++ b/svm
@@ -409,7 +409,9 @@ switch(){
     fi
   fi
 
-  rm "${BASE_DIR}/current"
+  if [ -h "${BASE_DIR}/current" ] ; then
+    rm "${BASE_DIR}/current"
+  fi
   ln -fs "scala-${version}" "${BASE_DIR}/current"
   echo "currently version is $1"
 }


### PR DESCRIPTION
初めてScalaをインストールしてcurrent runtime versionをダウンロードしたバージョンに切り替えようとした時に以下のエラーが発生する不具合を修正。

```
svm 412行: rm: `/home/mollifier/.svm/current' を削除できません: そのようなファイルやディレクトリはありません
```

存在しないファイルを削除しようとしているため、`-h` で指定された名前のシンボリックリンクが存在するかチェックするように修正。
