### PR TITLE
fixed typo

### DIFF
--- a/svm
+++ b/svm
@@ -158,7 +158,7 @@ Action :
   -h|help             - show this usage information
   -c|current          - show the currently use scala version
   -l|list             - show the scala version installed in svm_path(default is $HOME/.svm)
-  -v|versions         - show the abalabe scala version not installed
+  -v|versions         - show the available scala version not installed
   -i|install          - install specific scala version
   -r|remove|uninstall - uninstall specific scala version and remove their sources
   -s|switch|-u|use    - setup to use a specific scala version


### PR DESCRIPTION
I'm suspecting this is typo for available. Google shows about 8,000 records for the word abalabe, but I cannot find any definition which seem to be appropriate here.